### PR TITLE
[고도화] 엔티티 코드 스타일 정리 및 코드 리팩토링

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -35,8 +35,12 @@ public class Article extends AuditingFields {
   @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
   private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY) private Long id;
-  @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId")
+
+  @Setter
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "userId")
   private UserAccount userAccount;//유저정보(ID)
+
   @Setter @Column(nullable = false) private String title; // 제목
   @Setter @Column(nullable = false, length = 10000) private String content; // 본문
   @Setter private String hashtag; // 해시태그

--- a/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -60,20 +60,20 @@ public class Article extends AuditingFields {
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(id);
-  }
-
-  @Override
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
     }
     //데이터베이스 영속화 되지 않았다면 같은 개체로 보지 않는다는 처리.
-    if (!(obj instanceof Article article)) {
+    if (!(obj instanceof Article that)) {
       return false;
     }
-    return id != null && id.equals(article.id);
+    return this.getId() != null && this.getId().equals(that.getId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.getId());
   }
 
 }

--- a/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -51,19 +51,19 @@ public class ArticleComment extends AuditingFields {
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(id);
-  }
-
-  @Override
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
     }
-    if (!(obj instanceof ArticleComment articleComment)) {
+    if (!(obj instanceof ArticleComment that)) {
       return false;
     }
-    return id != null && id.equals(articleComment.id);
+    return this.getId() != null && this.getId().equals(that.getId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.getId());
   }
 
 }

--- a/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -26,10 +26,15 @@ public class ArticleComment extends AuditingFields {
 
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY) private Long id;
 
-  @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId")
+  @Setter
+  @ManyToOne(optional = false)
+  private Article article; // 게시글 (ID)
+
+  @Setter
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "userId")
   private UserAccount userAccount;//유저정보(ID)
 
-  @Setter @ManyToOne(optional = false) private Article article; // 게시글 (ID)
   @Setter @Column(nullable = false, length = 500) private String content; // 본문
 
   protected ArticleComment() {

--- a/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -24,7 +24,8 @@ import lombok.ToString;
 public class UserAccount extends AuditingFields {
 
   @Id
-  @Column(length = 50) private String userId;
+  @Column(length = 50)
+  private String userId;
 
   @Setter @Column(nullable = false) private String userPassword;
 
@@ -67,15 +68,15 @@ public class UserAccount extends AuditingFields {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof UserAccount userAccount)) {
+    if (!(o instanceof UserAccount that)) {
       return false;
     }
-    return userId != null && userId.equals(userAccount.userId);
+    return this.getUserId() != null && this.getUserId().equals(that.getUserId());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(userId);
+    return Objects.hash(this.getUserId());
   }
 
 }


### PR DESCRIPTION
연관관계 필드의 스타일을 간단히 정리하였다.

엔티티의 `equals()`, `hashcode()`가 값 비료를 위해 필드를 직접 접근 하는 것을 getter접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.